### PR TITLE
Implement unread counter that doesn't rely on generated class names

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -7,25 +7,6 @@ function getStyle(el, styleProp) {
     // (hypen separated words eg. font-Size)
     styleProp = styleProp.replace(/([A-Z])/g, "-$1").toLowerCase();
     return defaultView.getComputedStyle(el, null).getPropertyValue(styleProp);
-  } else if (el.currentStyle) { // IE
-    // sanitize property name to camelCase
-    styleProp = styleProp.replace(/\-(\w)/g, function(str, letter) {
-      return letter.toUpperCase();
-    });
-    value = el.currentStyle[styleProp];
-    // convert other units to pixels on IE
-    if (/^\d+(em|pt|%|ex)?$/i.test(value)) { 
-      return (function(value) {
-        var oldLeft = el.style.left, oldRsLeft = el.runtimeStyle.left;
-        el.runtimeStyle.left = el.currentStyle.left;
-        el.style.left = value || 0;
-        value = el.style.pixelLeft + "px";
-        el.style.left = oldLeft;
-        el.runtimeStyle.left = oldRsLeft;
-        return value;
-      })(value);
-    }
-    return value;
   }
 }
 
@@ -35,7 +16,9 @@ module.exports = (Franz) => {
 
     let unreadCount = 0;
     for (let i = 0; i < messages.length; i++) {
-      if (getStyle(messages[i], "fontWeight") === "600") {
+      // at the time, 400 is normal, and 600 is bold. 500 is halfway in between
+      // this should give some leeway if Google decides to change the weight a little
+      if (parseFloat(getStyle(messages[i], "fontWeight")) > 500) {
         unreadCount++;
       }
     }

--- a/webview.js
+++ b/webview.js
@@ -1,6 +1,44 @@
+// Gets the computed style. Pulled from https://stackoverflow.com/a/2664055/544326
+function getStyle(el, styleProp) {
+  var value, defaultView = (el.ownerDocument || document).defaultView;
+  // W3C standard way:
+  if (defaultView && defaultView.getComputedStyle) {
+    // sanitize property name to css notation
+    // (hypen separated words eg. font-Size)
+    styleProp = styleProp.replace(/([A-Z])/g, "-$1").toLowerCase();
+    return defaultView.getComputedStyle(el, null).getPropertyValue(styleProp);
+  } else if (el.currentStyle) { // IE
+    // sanitize property name to camelCase
+    styleProp = styleProp.replace(/\-(\w)/g, function(str, letter) {
+      return letter.toUpperCase();
+    });
+    value = el.currentStyle[styleProp];
+    // convert other units to pixels on IE
+    if (/^\d+(em|pt|%|ex)?$/i.test(value)) { 
+      return (function(value) {
+        var oldLeft = el.style.left, oldRsLeft = el.runtimeStyle.left;
+        el.runtimeStyle.left = el.currentStyle.left;
+        el.style.left = value || 0;
+        value = el.style.pixelLeft + "px";
+        el.style.left = oldLeft;
+        el.runtimeStyle.left = oldRsLeft;
+        return value;
+      })(value);
+    }
+    return value;
+  }
+}
+
 module.exports = (Franz) => {
   function getMessages() {
-    const unreadCount = document.querySelectorAll('.tpEAA.yrs5ff').length;
+    const messages = document.querySelectorAll('[aria-label=Conversations]>content span:not([class])');
+
+    let unreadCount = 0;
+    for (let i = 0; i < messages.length; i++) {
+      if (getStyle(messages[i], "fontWeight") === "600") {
+        unreadCount++;
+      }
+    }
 
     // set Franz badge
     Franz.setBadge(unreadCount);


### PR DESCRIPTION
Per my comment on https://github.com/meetfranz/plugins/pull/169, I figured I'd go ahead and see if a better method of getting the unread count would be feasible. I have tested this implementation, and it does work.

Essentially, it uses an aria label to find the messages, and grabs the spans without a class (which is currently only the message preview in the sidebar of the message). It checks to fontWeight for the span to see if it's bold to see whether or not it's an unread message.

This relies on the fontWeight not changing, as well as not having more spans with no classes. However, I feel this is more reliable than the current method which uses class names that appear to be generated upon building the web app.