### PR TITLE
Update messages URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Daniel Weinberger",
   "license": "MIT",
   "config": {
-    "serviceURL": "https://messages.android.com/",
+    "serviceURL": "https://messages.google.com/web",
     "hasNotificationSound": true
   }
 }


### PR DESCRIPTION
[Google has changed the URL](https://9to5google.com/2018/12/26/google-moving-messages-web-android-google-com/) for Android Messages from https://messages.android.com/ to https://messages.google.com/web and currently this throws a redirect message on load in Franz.

![Screen Shot 2019-03-27 at 10 14 58 AM](https://user-images.githubusercontent.com/7256402/55083285-a621ab00-5079-11e9-8de9-ec31238d5edb.png)

This PR updates to the new official URL.